### PR TITLE
chore: release v1.2.2

### DIFF
--- a/android/app/src/main/kotlin/com/example/waitwhat/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/waitwhat/MainActivity.kt
@@ -22,6 +22,7 @@ class MainActivity : FlutterActivity() {
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
+        NotificationReceiver.createChannel(this)
 
         MethodChannel(
             flutterEngine.dartExecutor.binaryMessenger,

--- a/android/app/src/main/kotlin/com/example/waitwhat/NotificationReceiver.kt
+++ b/android/app/src/main/kotlin/com/example/waitwhat/NotificationReceiver.kt
@@ -27,15 +27,15 @@ class NotificationReceiver : BroadcastReceiver() {
         private const val CHANNEL_ID = "waitwhat_todos"
         private const val CHANNEL_NAME = "Todos"
 
+        fun createChannel(context: Context) {
+            val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            manager.createNotificationChannel(
+                NotificationChannel(CHANNEL_ID, CHANNEL_NAME, NotificationManager.IMPORTANCE_DEFAULT)
+            )
+        }
+
         fun showNotification(context: Context, id: Int, title: String, body: String) {
             val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-
-            val channel = NotificationChannel(
-                CHANNEL_ID,
-                CHANNEL_NAME,
-                NotificationManager.IMPORTANCE_DEFAULT,
-            )
-            manager.createNotificationChannel(channel)
 
             val openIntent = android.content.Intent(context, MainActivity::class.java).apply {
                 action = "OPEN_TODOS"

--- a/lib/screens/sender_filter_screen.dart
+++ b/lib/screens/sender_filter_screen.dart
@@ -93,8 +93,10 @@ class _AddSenderSheetState extends State<_AddSenderSheet>
 
   Future<void> _loadSenders() async {
     final db = DatabaseService.instance;
-    final existing = await db.getAllSenders();
-    final seenSenders = await db.getSeenSenderNames();
+    final existingFuture = db.getAllSenders();
+    final seenFuture = db.getSeenSenderNames();
+    final existing = await existingFuture;
+    final seenSenders = await seenFuture;
     if (!mounted) return;
     setState(() {
       _existingSenders = existing.map((s) => s.name).toSet();

--- a/lib/screens/todos_screen.dart
+++ b/lib/screens/todos_screen.dart
@@ -72,15 +72,13 @@ class TodosScreen extends StatelessWidget {
           ),
           Expanded(
             child: StreamBuilder<List<Todo>>(
-              stream: DatabaseService.instance.watchTodos(),
+              stream: DatabaseService.instance.watchTodos().map(TodoSorter.byDueDate),
               builder: (context, snapshot) {
                 if (!snapshot.hasData) {
                   return const Center(child: CircularProgressIndicator());
                 }
-                final todos = snapshot.data!;
-                if (todos.isEmpty) return const _EmptyState();
-
-                final sorted = TodoSorter.byDueDate(todos);
+                final sorted = snapshot.data!;
+                if (sorted.isEmpty) return const _EmptyState();
 
                 return ListView.builder(
                   itemCount: sorted.length + 1,

--- a/lib/services/ai_service.dart
+++ b/lib/services/ai_service.dart
@@ -17,6 +17,10 @@ class AiService {
   static const _endpoint = 'https://api.groq.com/openai/v1/chat/completions';
   static const _model = 'llama-3.1-8b-instant';
 
+  static const _maxCache = 100;
+  static final _cache = <String, AiSuggestion?>{};
+
+
   static String _prompt(String sender, String body) {
     final now = DateTime.now();
     final today =
@@ -72,6 +76,8 @@ $body
     required String apiKey,
     http.Client? client,
   }) async {
+    final key = '$sender\x00$body';
+    if (_cache.containsKey(key)) return _cache[key];
     final c = client ?? http.Client();
     try {
       final response = await c.post(
@@ -98,7 +104,7 @@ $body
           (json['choices'] as List).first['message']['content'] as String;
       final data = jsonDecode(content) as Map<String, dynamic>;
 
-      if (data['needsTodo'] == false) return null;
+      if (data['needsTodo'] == false) return _cache[key] = null;
 
       final dueDateStr = data['dueDate'];
       DateTime? dueDate;
@@ -114,7 +120,9 @@ $body
         _ => Priority.medium,
       };
 
-      return AiSuggestion(dueDate: dueDate, priority: priority);
+      final result = AiSuggestion(dueDate: dueDate, priority: priority);
+      if (_cache.length >= _maxCache) _cache.remove(_cache.keys.first);
+      return _cache[key] = result;
     } catch (e) {
       if (e is AiQuotaExceededException) rethrow;
       final msg = e.toString().toLowerCase();

--- a/lib/services/app_init_service.dart
+++ b/lib/services/app_init_service.dart
@@ -9,6 +9,7 @@ class AppInitService {
 
   static Future<void> initialize() async {
     DatabaseService.initialize();
+    await SettingsService.initialize();
     await SettingsService.loadQuotaState();
     await PushNotificationService.initialize();
     await PushNotificationService.requestPermission();

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -23,11 +23,13 @@ class NotificationService {
   static final _recentKeys = <String, DateTime>{};
 
   // All senders seen in WhatsApp notifications this session (pre-filter).
+  static const _maxSeenSenders = 500;
   static final seenSenders = <String>{};
 
   @visibleForTesting
   static void trackSender(String sender, String? body) {
     if (body == null || body.trim().isEmpty) return;
+    if (seenSenders.length >= _maxSeenSenders) seenSenders.remove(seenSenders.first);
     seenSenders.add(sender);
   }
 

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -19,6 +19,7 @@ class NotificationService {
 
   // Tracks recently seen (sender, body) keys to deduplicate WhatsApp's
   // duplicate notification events for the same message.
+  static const _maxRecentKeys = 1000;
   static final _recentKeys = <String, DateTime>{};
 
   // All senders seen in WhatsApp notifications this session (pre-filter).
@@ -74,6 +75,7 @@ class NotificationService {
 
     final last = _recentKeys[key];
     if (last != null && now.difference(last).inSeconds < 2) return;
+    if (_recentKeys.length >= _maxRecentKeys) _recentKeys.remove(_recentKeys.keys.first);
     _recentKeys[key] = now;
     _recentKeys.removeWhere((_, t) => now.difference(t).inSeconds > 10);
 

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -5,86 +5,78 @@ import '../config.dart';
 class SettingsService {
   static const _groqKeyPref = 'groq_api_key';
   static const _groqQuotaExhaustedPref = 'groq_quota_exhausted';
+  static const _dailyReminderEnabledPref = 'daily_reminder_enabled';
+  static const _dailyReminderHourPref = 'daily_reminder_hour';
+  static const _dailyReminderMinutePref = 'daily_reminder_minute';
+  static const _autoCreateTodosPref = 'auto_create_todos';
+
+  static late SharedPreferences _prefs;
 
   static final quotaExhaustedNotifier = ValueNotifier<bool>(false);
+
+  static Future<void> initialize() async {
+    _prefs = await SharedPreferences.getInstance();
+  }
 
   static Future<void> loadQuotaState() async {
     quotaExhaustedNotifier.value = await isGroqQuotaExhausted();
   }
 
   static Future<String?> getGroqApiKey() async {
-    final prefs = await SharedPreferences.getInstance();
-    final saved = prefs.getString(_groqKeyPref);
+    final saved = _prefs.getString(_groqKeyPref);
     if (saved != null && saved.isNotEmpty) return saved;
     return kGroqApiKey.isNotEmpty ? kGroqApiKey : null;
   }
 
   static Future<void> saveGroqApiKey(String key) async {
-    final prefs = await SharedPreferences.getInstance();
     if (key.trim().isEmpty) {
-      await prefs.remove(_groqKeyPref);
+      await _prefs.remove(_groqKeyPref);
     } else {
-      await prefs.setString(_groqKeyPref, key.trim());
-      await prefs.remove(_groqQuotaExhaustedPref);
+      await _prefs.setString(_groqKeyPref, key.trim());
+      await _prefs.remove(_groqQuotaExhaustedPref);
       quotaExhaustedNotifier.value = false;
     }
   }
 
   static Future<bool> isGroqQuotaExhausted() async {
-    final prefs = await SharedPreferences.getInstance();
-    return prefs.getBool(_groqQuotaExhaustedPref) ?? false;
+    return _prefs.getBool(_groqQuotaExhaustedPref) ?? false;
   }
 
   static Future<void> setGroqQuotaExhausted() async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(_groqQuotaExhaustedPref, true);
+    await _prefs.setBool(_groqQuotaExhaustedPref, true);
     quotaExhaustedNotifier.value = true;
   }
 
   static Future<void> clearGroqQuotaExhausted() async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.remove(_groqQuotaExhaustedPref);
+    await _prefs.remove(_groqQuotaExhaustedPref);
     quotaExhaustedNotifier.value = false;
   }
 
-  static const _dailyReminderEnabledPref = 'daily_reminder_enabled';
-  static const _dailyReminderHourPref = 'daily_reminder_hour';
-  static const _dailyReminderMinutePref = 'daily_reminder_minute';
-
   static Future<bool> getDailyReminderEnabled() async {
-    final prefs = await SharedPreferences.getInstance();
-    return prefs.getBool(_dailyReminderEnabledPref) ?? false;
+    return _prefs.getBool(_dailyReminderEnabledPref) ?? false;
   }
 
   static Future<void> setDailyReminderEnabled(bool value) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(_dailyReminderEnabledPref, value);
+    await _prefs.setBool(_dailyReminderEnabledPref, value);
   }
 
   static Future<({int hour, int minute})> getDailyReminderTime() async {
-    final prefs = await SharedPreferences.getInstance();
     return (
-      hour: prefs.getInt(_dailyReminderHourPref) ?? 9,
-      minute: prefs.getInt(_dailyReminderMinutePref) ?? 0,
+      hour: _prefs.getInt(_dailyReminderHourPref) ?? 9,
+      minute: _prefs.getInt(_dailyReminderMinutePref) ?? 0,
     );
   }
 
   static Future<void> setDailyReminderTime(int hour, int minute) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setInt(_dailyReminderHourPref, hour);
-    await prefs.setInt(_dailyReminderMinutePref, minute);
+    await _prefs.setInt(_dailyReminderHourPref, hour);
+    await _prefs.setInt(_dailyReminderMinutePref, minute);
   }
 
-  static const _autoCreateTodosPref = 'auto_create_todos';
-
   static Future<bool> getAutoCreateTodos() async {
-    final prefs = await SharedPreferences.getInstance();
-    return prefs.getBool(_autoCreateTodosPref) ?? false;
+    return _prefs.getBool(_autoCreateTodosPref) ?? false;
   }
 
   static Future<void> setAutoCreateTodos(bool value) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(_autoCreateTodosPref, value);
+    await _prefs.setBool(_autoCreateTodosPref, value);
   }
-
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: waitwhat
 description: "A new Flutter project."
 publish_to: 'none'
-version: 1.2.1+4
+version: 1.2.2+5
 
 environment:
   sdk: ^3.11.5

--- a/test/services/settings_service_test.dart
+++ b/test/services/settings_service_test.dart
@@ -5,6 +5,7 @@ import 'package:waitwhat/services/settings_service.dart';
 void main() {
   setUp(() async {
     SharedPreferences.setMockInitialValues({});
+    await SettingsService.initialize();
     SettingsService.quotaExhaustedNotifier.value = false;
   });
 


### PR DESCRIPTION
## Improvements
- Cache AI suggestions to avoid redundant API calls
- Sort todos once per data change instead of on every build
- Run sender filter DB queries in parallel
- Cap seenSenders set size to prevent unbounded growth
- Cap _recentKeys map size with FIFO eviction
- Cache SharedPreferences instance in SettingsService
- Create notification channel once at startup instead of per notification

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)